### PR TITLE
feat : 게시글 리스트 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/wantedboard/config/QueryDslConfig.java
+++ b/src/main/java/com/example/wantedboard/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.example.wantedboard.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    public EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}
+
+

--- a/src/main/java/com/example/wantedboard/controller/PostController.java
+++ b/src/main/java/com/example/wantedboard/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.example.wantedboard.controller;
 
 import com.example.wantedboard.request.PostCreate;
+import com.example.wantedboard.request.PostSearch;
 import com.example.wantedboard.response.PostResponse;
 import com.example.wantedboard.response.ResponseDto;
 import com.example.wantedboard.service.PostService;
@@ -11,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static org.springframework.http.HttpStatus.OK;
 
@@ -23,7 +26,6 @@ public class PostController {
 
     @PostMapping("/posts")
     public ResponseEntity<?> post(@RequestBody @Valid PostCreate postCreate, BindingResult bindingResult) {
-        log.info("디버그 : {}", postCreate);
         postService.write(postCreate);
         return new ResponseEntity<>(new ResponseDto<>(1, "글 작성을 성공했습니다.", null), HttpStatus.OK);
     }
@@ -32,5 +34,11 @@ public class PostController {
     public ResponseEntity<?> get(@PathVariable Long postId) {
         final PostResponse postResponse = postService.get(postId);
         return new ResponseEntity<>(new ResponseDto<>(1, "글 조회에 성공했습니다.", postResponse), OK);
+    }
+
+    @GetMapping("/posts")
+    public ResponseEntity<?> getList(@ModelAttribute PostSearch postSearch) {
+        final List<PostResponse> postList = postService.getList(postSearch);
+        return new ResponseEntity<>(new ResponseDto<>(1, "글 리스트 조회를 성공했습니다.", postList), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/wantedboard/postrepository/PostRepository.java
+++ b/src/main/java/com/example/wantedboard/postrepository/PostRepository.java
@@ -1,7 +1,9 @@
 package com.example.wantedboard.postrepository;
 
+
 import com.example.wantedboard.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 }
+

--- a/src/main/java/com/example/wantedboard/postrepository/PostRepositoryCustom.java
+++ b/src/main/java/com/example/wantedboard/postrepository/PostRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.example.wantedboard.postrepository;
+
+
+import com.example.wantedboard.domain.Post;
+import com.example.wantedboard.request.PostSearch;
+
+import java.util.List;
+
+public interface PostRepositoryCustom {
+
+    List<Post> getList(PostSearch postSearch);
+}

--- a/src/main/java/com/example/wantedboard/postrepository/PostRepositoryImpl.java
+++ b/src/main/java/com/example/wantedboard/postrepository/PostRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.example.wantedboard.postrepository;
+
+import com.example.wantedboard.domain.Post;
+import com.example.wantedboard.domain.QPost;
+import com.example.wantedboard.request.PostSearch;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Post> getList(final PostSearch postSearch) {
+        return jpaQueryFactory.selectFrom(QPost.post)
+                .limit(postSearch.getSize())
+                .offset(postSearch.getOffset())
+                .orderBy(QPost.post.id.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/wantedboard/request/PostSearch.java
+++ b/src/main/java/com/example/wantedboard/request/PostSearch.java
@@ -1,0 +1,24 @@
+package com.example.wantedboard.request;
+
+import lombok.*;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostSearch {
+    private final int MAX_SIZE = 2000;
+
+    @Builder.Default
+    private int page = 1;
+    @Builder.Default
+    private int size = 10;
+
+    public long getOffset() {
+        return (long) (max(1, page) - 1) * min(size, MAX_SIZE);
+    }
+}

--- a/src/main/java/com/example/wantedboard/response/PostResponse.java
+++ b/src/main/java/com/example/wantedboard/response/PostResponse.java
@@ -1,5 +1,6 @@
 package com.example.wantedboard.response;
 
+import com.example.wantedboard.domain.Post;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,6 +9,10 @@ public class PostResponse {
     private final String title;
     private final String content;
 
+    public PostResponse(Post post) {
+        this.title = post.getTitle();
+        this.content = post.getContent();
+    }
     @Builder
     public PostResponse(final String title, final String content) {
         this.title = title;

--- a/src/main/java/com/example/wantedboard/service/PostService.java
+++ b/src/main/java/com/example/wantedboard/service/PostService.java
@@ -4,8 +4,12 @@ import com.example.wantedboard.aop.CustomApiException;
 import com.example.wantedboard.domain.Post;
 import com.example.wantedboard.postrepository.PostRepository;
 import com.example.wantedboard.request.PostCreate;
+import com.example.wantedboard.request.PostSearch;
 import com.example.wantedboard.response.PostResponse;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class PostService {
@@ -30,5 +34,11 @@ public class PostService {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .build();
+    }
+
+    public List<PostResponse> getList(PostSearch postSearch) {
+        return postRepository.getList(postSearch).stream()
+                .map(PostResponse::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/example/wantedboard/controller/PostControllerTest.java
+++ b/src/test/java/com/example/wantedboard/controller/PostControllerTest.java
@@ -14,6 +14,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -53,7 +57,6 @@ class PostControllerTest {
                 .andDo(print())
         ;
     }
-
     @Test
     @DisplayName("/posts 요청시 title 필수")
     void 작성실패1() throws Exception {
@@ -130,5 +133,34 @@ class PostControllerTest {
                 .andDo(print())
         ;
         verify(postService).get(1L);
+    }
+
+    @Test
+    @DisplayName("글 여러개 조회 성공")
+    void 글_여러개조회성공() throws Exception {
+        //given
+        List<PostResponse> requestPosts = IntStream.range(1, 11)
+                .mapToObj(i -> {
+                    return PostResponse.builder()
+                            .title("Title " + i)
+                            .content("Content " + i)
+                            .build();
+                })
+                .collect(Collectors.toList());
+        //stub
+        given(postService.getList(any())).willReturn(requestPosts);
+
+        //when
+        mockMvc.perform(get("/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.message").value("글 리스트 조회를 성공했습니다."))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.size()").value(10))
+                .andDo(print())
+        ;
+        verify(postService).getList(any());
     }
 }

--- a/src/test/java/com/example/wantedboard/service/PostServiceTest.java
+++ b/src/test/java/com/example/wantedboard/service/PostServiceTest.java
@@ -3,6 +3,7 @@ package com.example.wantedboard.service;
 import com.example.wantedboard.domain.Post;
 import com.example.wantedboard.postrepository.PostRepository;
 import com.example.wantedboard.request.PostCreate;
+import com.example.wantedboard.request.PostSearch;
 import com.example.wantedboard.response.PostResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -70,5 +74,28 @@ class PostServiceTest {
         assertThat(postOneResponse).isNotNull();
         assertThat(postOneResponse.getContent()).isEqualTo(oneResponse.getContent());
         assertThat(postOneResponse.getTitle()).isEqualTo(oneResponse.getTitle());
+    }
+
+    @Test
+    @DisplayName("글 1페이지 조회")
+    void test_list() {
+        //given
+        List<Post> response = IntStream.range(1, 6)
+                .mapToObj(i -> {
+                    return Post.builder()
+                            .title("Title " + i)
+                            .content("Content " + i)
+                            .build();
+                })
+                .collect(Collectors.toList());
+        // stub
+        given(postRepository.getList(any())).willReturn(response);
+
+        //when
+        PostSearch postSearch = new PostSearch();
+        final List<PostResponse> list = postService.getList(postSearch);
+
+        //then
+        assertThat(list.size()).isEqualTo(5);
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 게시글 리스트 조회 기능 추가
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- QueryDsl을 이용해 게시글 리스트 조회 기능 추가
- 게시글 검색 조건에 따른 확장성을 고려하여 QueryDsl 사용
