### PR TITLE
refector : 로그인 한 사용자만 게시글 등록 가능

### DIFF
--- a/src/main/java/com/example/wantedboard/config/jwt/JwtProcess.java
+++ b/src/main/java/com/example/wantedboard/config/jwt/JwtProcess.java
@@ -19,6 +19,7 @@ public class JwtProcess {
                 .withSubject("wanted")
                 .withExpiresAt(new Date(System.currentTimeMillis() + JwtVO.EXPIRATION_TIM))
                 .withClaim("id", loginUser.getUser().getId())
+                .withClaim("email", loginUser.getUser().getEmail())
                 .withClaim("role", loginUser.getUser().getUserRole().name())
                 .sign(Algorithm.HMAC512(JwtVO.SECRET));
 
@@ -29,8 +30,12 @@ public class JwtProcess {
 
         DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC512(JwtVO.SECRET)).build().verify(token);
         Long id = decodedJWT.getClaim("id").asLong();
+        String email = decodedJWT.getClaim("email").asString();
         String role = decodedJWT.getClaim("role").asString();
-        User user = User.builder().id(id).userRole(UserRole.valueOf(role)).build();
+        User user = User.builder()
+                .id(id)
+                .email(email)
+                .userRole(UserRole.valueOf(role)).build();
         LoginUser loginUser = new LoginUser(user);
 
         return loginUser;

--- a/src/main/java/com/example/wantedboard/controller/PostController.java
+++ b/src/main/java/com/example/wantedboard/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.example.wantedboard.controller;
 
+import com.example.wantedboard.config.auth.LoginUser;
 import com.example.wantedboard.request.PostCreate;
 import com.example.wantedboard.request.PostEdit;
 import com.example.wantedboard.request.PostSearch;
@@ -10,10 +11,13 @@ import com.example.wantedboard.util.StatusCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.security.Principal;
 import java.util.List;
 
 import static com.example.wantedboard.util.StatusCode.*;
@@ -26,9 +30,9 @@ public class PostController {
 
     private final PostService postService;
 
-    @PostMapping("/posts")
-    public ResponseEntity<?> post(@RequestBody @Valid PostCreate postCreate, BindingResult bindingResult) {
-        postService.write(postCreate);
+    @PostMapping("/user/posts")
+    public ResponseEntity<?> post(@RequestBody @Valid PostCreate postCreate, BindingResult bindingResult, @AuthenticationPrincipal LoginUser loginUser) {
+        postService.write(postCreate, loginUser.getUser().getEmail());
 
         return new ResponseEntity<>(ResponseDto.builder()
                 .code(SUCCESS.getValue())
@@ -64,7 +68,7 @@ public class PostController {
         );
     }
 
-    @PostMapping("/posts/{postId}")
+    @PostMapping("/user/posts/{postId}")
     public ResponseEntity<?> edit(@PathVariable Long postId, @RequestBody PostEdit postEdit) {
         postService.edit(postId, postEdit);
 
@@ -77,7 +81,7 @@ public class PostController {
         );
     }
 
-    @DeleteMapping("/posts/{postId}")
+    @DeleteMapping("/user/posts/{postId}")
     public ResponseEntity<?> delete(@PathVariable Long postId) {
         postService.delete(postId);
 

--- a/src/main/java/com/example/wantedboard/domain/Post.java
+++ b/src/main/java/com/example/wantedboard/domain/Post.java
@@ -18,6 +18,7 @@ public class Post {
     private String title;
 
     @ManyToOne
+    @JoinColumn
     private User user;
 
     @Builder
@@ -31,5 +32,9 @@ public class Post {
     public void change(String title, String content) {
         this.title = title != null ? title : this.title;
         this.content = content != null ? content : this.content;
+    }
+
+    public void addUser(final User user) {
+        this.user = user;
     }
 }

--- a/src/main/java/com/example/wantedboard/domain/User.java
+++ b/src/main/java/com/example/wantedboard/domain/User.java
@@ -17,8 +17,6 @@ public class User{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
-
     private String email;
 
     private String password;
@@ -29,9 +27,8 @@ public class User{
     private List<Post> posts;
 
     @Builder
-    public User(final Long id, final String name, final String email, final String password, final UserRole userRole) {
+    public User(final Long id, final String email, final String password, final UserRole userRole) {
         this.id = id;
-        this.name = name;
         this.email = email;
         this.password = password;
         this.userRole = userRole;

--- a/src/main/java/com/example/wantedboard/exception/UserNotFound.java
+++ b/src/main/java/com/example/wantedboard/exception/UserNotFound.java
@@ -1,0 +1,25 @@
+package com.example.wantedboard.exception;
+
+import org.springframework.http.HttpStatus;
+
+import static com.example.wantedboard.util.StatusCode.NOT_FOUND;
+
+public class UserNotFound extends CustomApiException{
+
+    private static final String MESSAGE = "존재하지 않는 이메일 입니다.";
+
+    public UserNotFound() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public String statusCode() {
+        return NOT_FOUND.getValue();
+    }
+
+    @Override
+    public HttpStatus HttpStatusCode() {
+        return HttpStatus.NOT_FOUND;
+    }
+
+}

--- a/src/main/java/com/example/wantedboard/service/PostService.java
+++ b/src/main/java/com/example/wantedboard/service/PostService.java
@@ -1,13 +1,16 @@
 package com.example.wantedboard.service;
 
-import com.example.wantedboard.exception.CustomApiException;
 import com.example.wantedboard.domain.Post;
+import com.example.wantedboard.domain.User;
 import com.example.wantedboard.exception.PostNotFound;
+import com.example.wantedboard.exception.UserNotFound;
 import com.example.wantedboard.postrepository.PostRepository;
+import com.example.wantedboard.postrepository.UserRepository;
 import com.example.wantedboard.request.PostCreate;
 import com.example.wantedboard.request.PostEdit;
 import com.example.wantedboard.request.PostSearch;
 import com.example.wantedboard.response.PostResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,17 +18,26 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class PostService {
 
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
 
-    public PostService(final PostRepository postRepository) {
-        this.postRepository = postRepository;
-    }
+    // todo PostId 반환하기
+    @Transactional
+    public PostResponse write(PostCreate postCreate, final String userEmail) {
+        var post = postRepository.save(postCreate.toEntity());
 
-    public PostResponse write(PostCreate postCreate) {
-        final Post post = postRepository.save(postCreate.toEntity());
-        return new PostResponse(post.getTitle(), post.getContent());
+        var user = userRepository.findByEmail(userEmail)
+                .orElseThrow(UserNotFound::new);
+
+        post.addUser(user);
+
+        return PostResponse.builder()
+                .title(post.getTitle())
+                .content(post.getContent())
+                .build();
     }
 
     public PostResponse get(final Long postId) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,13 +6,8 @@ spring:
 
 
   datasource:
-    url: jdbc:h2:mem:sns
+    url: jdbc:h2:mem:sns;NON_KEYWORDS=USER
     username: sa
     password:
     driver-class-name: org.h2.Driver
 
-  data:
-    web:
-      pageable:
-        one-indexed-parameters: true
-        default-page-size: 5


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [X] 리펙토링 : 로그인 한 사용자만 게시글 등록 가능
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 게시글의 작성자가 수정, 삭제를 할 수 있도록 로그인 한 사용자만 게시글 작성할 수 있게 변경

- 테스트 시 MockUser를 넣기 위해 WithUserDetails 어노테이션을 통해 테스트 실행 전 MockUser 주입

- 예상 가능한 변수 var 타입 변경
